### PR TITLE
Emit drain

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,10 @@ function Reader (fileOrPath, options) {
   if (options.watchDelay) this.watchDelay = options.watchDelay * 1000;
 
   this.lines        = { start: 0, position: 0, skip: 0 };
-  this.batch        = { count: 0, limit: 0 };
+  this.batch        = { count: 0, limit: 0, delay: 0 };
 
   if (options.batchLimit) this.batch.limit = options.batchLimit;
+  if (options.batchDelay) this.batch.delay = options.batchDelay;
 
   this.startReader();
 }
@@ -139,7 +140,7 @@ Reader.prototype.batchSaveDone = function (err, delay) {
 
     // the log shipper can ask us to wait 'delay' seconds before
     // emitting the next batch. This is useful as a backoff mechanism.
-    if (isNaN(delay)) delay = 5;
+    if (isNaN(delay)) delay = slr.batch.delay;
     if (delay) {
       console.log('\t\tpause ' + delay + ' seconds');
     }

--- a/lib/bookmark.js
+++ b/lib/bookmark.js
@@ -58,6 +58,7 @@ Bookmark.prototype.save = function(logFilePath, lines, done) {
       if (err) return done(err);
       fs.stat(tmpPath, function (err, stat) {
         if (err) return done(err);
+
         // verify the JSON string was written
         if (!stat.size) {
           return done('wrote an empty file!');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "safe-log-reader",
   "description": "Safe Log Reader",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "private": false,
   "keywords": [
     "log",

--- a/test/data/batch.log
+++ b/test/data/batch.log
@@ -1,0 +1,9 @@
+The rain in spain falls mainly on the plain.
+The rain in spain falls mainly on the plain.
+The rain in spain falls mainly on the plain.
+The rain in spain falls mainly on the plain.
+The rain in spain falls mainly on the plain.
+The rain in spain falls mainly on the plain.
+The rain in spain falls mainly on the plain.
+The rain in spain falls mainly on the plain.
+The rain in spain falls mainly on the plain.

--- a/test/reader.js
+++ b/test/reader.js
@@ -333,7 +333,7 @@ describe('reader', function () {
     });
   });
 
-  it('emits an end when batch is full', function (done) {
+  it('emits a drain when batch is full', function (done) {
     var filePath = path.join(dataDir, 'test.log');
 
     var r = reader.createReader(filePath, noBmReadOpts)
@@ -347,7 +347,7 @@ describe('reader', function () {
     .on('read', function (data) {
       assert.equal(data, undefined);
     })
-    .on('end', function (cb) {
+    .on('drain', function (cb) {
       cb();
       done();
     });

--- a/test/reader.js
+++ b/test/reader.js
@@ -51,6 +51,24 @@ describe('reader', function () {
     });
   });
 
+  it('reads batches of lines', function (done) {
+    var linesSeen = 0;
+    var filePath = path.join(dataDir, 'batch.log');
+    var batchOpts = JSON.parse(JSON.stringify(readerOpts));
+    batchOpts.batchLimit = 2;
+
+    reader.createReader(filePath, batchOpts)
+    .on('readable', function () { this.readLine(); })
+    .on('read', function (data, lines, bytes) {
+      linesSeen++;
+      assert.equal(data, logLine);
+      if (linesSeen === 9) done();
+    })
+    .on('drain', function (done) {
+      done(null, 0);
+    });
+  });
+
   it('maintains an accurate line counter', function (done) {
     var linesSeen = 0;
     var filePath = path.join(dataDir, 'test.log.1');


### PR DESCRIPTION
# change

* bookmark.save() only classed in one place (was at EOF and end-of-batch). Now an EOF emits a "batch drain" event instead.
* on batch end, wrap "save bookmark and call done" callback in a nextTick, so that `return true;` always completes first (less racey).
* moved the "batch is done" callback into batchSaveDone();
* at the end of batchSaveDone(), emit batchCount readLines(), since the batching interrupted the normal emit-them-all-as-fast-as-possible flow.

# new feature

* batchDelay default can be passed in as an option (was 5 seconds unless provided in batch.done(), a reasonable default for logship-postfix, not so much for logship-qp)